### PR TITLE
Add 'wrap lines' button to opt view

### DIFF
--- a/static/panes/opt-view.ts
+++ b/static/panes/opt-view.ts
@@ -51,10 +51,13 @@ export class Opt extends MonacoPane<monaco.editor.IStandaloneCodeEditor, OptStat
     // Note: bool | undef here instead of just bool because of an issue with field initialization order
     isCompilerSupported?: boolean;
     filters: Toggles;
+    toggleWrapButton: Toggles;
+    wrapButton: JQuery<HTMLElementTagNameMap[keyof HTMLElementTagNameMap]>;
 
     // Keep optRemarks as state, to avoid triggerring a recompile when options change
     optRemarks: OptCodeEntry[];
     srcAsOptview: OptviewLine[];
+    wrapTitle: string;
 
     constructor(hub: Hub, container: Container, state: OptState & MonacoPaneState) {
         super(hub, container, state);
@@ -93,6 +96,13 @@ export class Opt extends MonacoPane<monaco.editor.IStandaloneCodeEditor, OptStat
         super.registerButtons(state);
         this.filters = new Toggles(this.domRoot.find('.filters'), state as unknown as Record<string, boolean>);
         this.filters.on('change', this.showOptRemarks.bind(this));
+
+        this.wrapButton = this.domRoot.find('.wrap-lines');
+        this.wrapTitle = this.wrapButton.prop('title');
+
+        this.toggleWrapButton = new Toggles(this.domRoot.find('.options'), state as unknown as Record<string, boolean>);
+        this.toggleWrapButton.on('change', this.onToggleWrapChange.bind(this));
+        this.onToggleWrapChange();
     }
 
     override registerCallbacks() {
@@ -151,6 +161,12 @@ export class Opt extends MonacoPane<monaco.editor.IStandaloneCodeEditor, OptStat
 
     override getDefaultPaneName() {
         return 'Opt Viewer';
+    }
+
+    onToggleWrapChange(): void {
+        const curWrap = this.toggleWrapButton.get()['wrap'];
+        this.wrapButton.prop('title', '[' + (curWrap ? 'ON' : 'OFF') + '] ' + this.wrapTitle);
+        this.editor.updateOptions({wordWrap: curWrap ? 'on' : 'off'});
     }
 
     showOptRemarks() {
@@ -219,6 +235,7 @@ export class Opt extends MonacoPane<monaco.editor.IStandaloneCodeEditor, OptStat
     override getCurrentState() {
         return {
             ...this.filters.get(),
+            ...this.toggleWrapButton.get(),
             ...super.getCurrentState(),
         };
     }

--- a/views/templates/panes/opt-view.pug
+++ b/views/templates/panes/opt-view.pug
@@ -7,6 +7,11 @@ mixin optionButton(bind, isActive, text, title)
 #opt-view
   .top-bar.btn-toolbar.bg-light(role="toolbar")
     include ../../font-size
+    .btn-group.btn-group-sm.options(role="group" aria-label="Output options")
+      .button-checkbox
+        button.btn.btn-sm.btn-light.wrap-lines(type="button" title="Wrap lines" data-bind="wrap" aria-pressed="false" aria-label="Wrap lines")
+          span Wrap lines
+        input.d-none(type="checkbox" checked=false)
     // TODO: Options -  display inlining context, color token (from col-num), remove duplicates
     .btn-group.btn-group-sm.filters(role="group")
       button.btn.btn-sm.btn-light.dropdown-toggle(type="button" title="Opt-Remarks Filters" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-label="Set output filters")


### PR DESCRIPTION
![wrapopt](https://github.com/OfekShilon/compiler-explorer/assets/73080/cefb0e37-ec1b-4d4d-8619-5699a2c4d937)

I initially intended to wrap just the remarks and not the source, but realized (1) it would look awkward, (2) it's [probably impossible](https://microsoft.github.io/monaco-editor/playground.html?source=v0.48.0#XQAAAAKyAwAAAAAAAABBqQkHQ5NjdMjwa-jY7SIQ9S7DNlzs5W-mwj0fe1ZCDRFc9ws9XQE0SJE1jc2VKxhaLFIw9vEWSxW3yscw29XwoDpMOA-gxSZZQzExMf_pXDZyTsy3Atmz6k8P-HZ6DXfbO1_IuM5YfPjwXfFkpBXsGewkWvURK94eqmf054CkC5r1J9D8k9aF9r7L2DRGrIJhIckFhjmaqeIdXVXPjbsW09FT0wz5oCpFyuiWlsOYvU5iSkJzs8Q7XsJ9Cbk458ltX8cSGxqK0TlKhbjUR-t_GCEiioGUNWi2PfGGIXrFw-FUBUxvivlbsyVrIf3Z-AJ3V9HijIxLZv_MGGejCwlCkMd0cvzJPeoi1aserMfYDvQzq1PmPI2AcUU2hlYoSMYZ97dj1aLDPl-z8_kCLwWQn3XUcERpJAMByyH3sSlNSuZC4td-jMVGTHy8IZnLKJn4s8W1e0TESj-8yMKi_YordAInUxFE6YbwKxTanmg3Gh4_-j-8K_T2BUKlP2OcpTEvfoOsOVDunyDT2RcWvM8dU0yl84F10GZxqcdbMm3ciw3bQ-8_lAzov31MKizeiWBHmLKcv6QzHgKIQhkyJh3af4v-VolN9ZDDvxmKI9QWZubIo2iONApZ1elsA2J6Lz8D4VT7FhiYMvf_1L2NHA) without breaking all monaco abstractions.

The demangler isn't properly found on my local instance so these remarks are not demangled. In the live site they are. I wonder if there is a point in adding a toggle option for demangling, as in other panes.